### PR TITLE
Fix segfault in set_memory_limit

### DIFF
--- a/quickjs/__init__.py
+++ b/quickjs/__init__.py
@@ -46,10 +46,6 @@ class Function:
             return future.result()
 
     def set_memory_limit(self, limit):
-        # TODO: Remove this when quickjs does not crash when running out of
-        # memory (since version 2019-12-21).
-        raise Exception("Setting memory limit is currently disabled")
-
         with self._lock:
             return self._context.set_memory_limit(limit)
 

--- a/test_quickjs.py
+++ b/test_quickjs.py
@@ -81,7 +81,6 @@ class Context(unittest.TestCase):
         # The context has left the scope after f. f needs to keep the context alive for the
         # its lifetime. Otherwise, we will get problems.
 
-    @unittest.skip
     def test_memory_limit(self):
         code = """
             (function() {

--- a/third-party/quickjs.c
+++ b/third-party/quickjs.c
@@ -6146,6 +6146,10 @@ static JSValue JS_ThrowError2(JSContext *ctx, JSErrorEnum error_num,
     char buf[256];
     JSValue obj, ret;
 
+    if (ctx->in_out_of_memory) {
+        return JS_Throw(ctx, JS_NULL);
+    }
+
     vsnprintf(buf, sizeof(buf), fmt, ap);
     obj = JS_NewObjectProtoClass(ctx, ctx->native_error_proto[error_num],
                                  JS_CLASS_ERROR);


### PR DESCRIPTION
Did some debugging and it seems that this fixes the issue. Obviously, it would be better if this patch was checked into upstream quickjs (have made this suggestion).