### PR TITLE
Fix static linking on Windows.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ _quickjs = Extension(
     # HACK.
     # See https://github.com/pypa/packaging-problems/issues/84.
     sources=get_c_sources(include_headers=("sdist" in sys.argv)),
-    extra_compile_args=["-static", "-static-libgcc", "-static-libstdc++"],
     extra_link_args=extra_link_args)
 
 long_description = """

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ if sys.platform == "win32":
     CONFIG_VERSION = f'\\"{CONFIG_VERSION}\\"'
     # Make sure that pthreads is linked statically, otherwise we run into problems
     # on computers where it is not installed.
-    extra_link_args = ["-Wl,-Bstatic", "-lpthread"]
+    extra_link_args = ["-Wl,-Bstatic", "-lpthread", "-static"]
 else:
     CONFIG_VERSION = f'"{CONFIG_VERSION}"'
 
@@ -39,6 +39,7 @@ _quickjs = Extension(
     # HACK.
     # See https://github.com/pypa/packaging-problems/issues/84.
     sources=get_c_sources(include_headers=("sdist" in sys.argv)),
+    extra_compile_args=["-static", "-static-libgcc", "-static-libstdc++"],
     extra_link_args=extra_link_args)
 
 long_description = """
@@ -55,7 +56,7 @@ setup(author="Petter Strandmark",
       author_email="petter.strandmark@gmail.com",
       name='quickjs',
       url='https://github.com/PetterS/quickjs',
-      version='1.9.0',
+      version='1.10.0',
       description='Wrapping the quickjs C library.',
       long_description=long_description,
       packages=["quickjs"],

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ if sys.platform == "win32":
     CONFIG_VERSION = f'\\"{CONFIG_VERSION}\\"'
     # Make sure that pthreads is linked statically, otherwise we run into problems
     # on computers where it is not installed.
-    extra_link_args = ["-Wl,-Bstatic", "-lpthread", "-static"]
+    extra_link_args = ["-static"]
 else:
     CONFIG_VERSION = f'"{CONFIG_VERSION}"'
 


### PR DESCRIPTION
Fixes #25

I added the flag for C++ as well, just in case we or anyone else copies this at some point. There really aren't any good instructions for building Python extensions on Windows with a free compiler.

Before
====
![before](https://user-images.githubusercontent.com/772305/73296333-cfffad00-4209-11ea-9439-6935ec4d81c7.PNG)

After
====
![after](https://user-images.githubusercontent.com/772305/73296352-d8f07e80-4209-11ea-94c0-e962fa5e2cf3.PNG)
