### PR TITLE
Use Python 3.8.2 in CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.6.6
+      - image: circleci/python:3.8.2
 
     working_directory: ~/repo
 
@@ -17,7 +17,7 @@ jobs:
 
       - restore_cache:
           keys:
-          - v2-dependencies-{{ checksum "poetry.lock" }}
+          - v3-3.8.2-dependencies-{{ checksum "poetry.lock" }}
 
       - run:
           name: Install dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,10 +32,6 @@ jobs:
           key: v3-3.8.2-dependencies-{{ checksum "poetry.lock" }}
 
       - run:
-          name: test_bool
-          command: poetry run python -m unittest test_quickjs.FunctionTest.test_bool
-      
-      - run:
           name: Tests
           command: |
             make test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,8 +29,12 @@ jobs:
           paths:
             - ./.venv
             - ~/.cache/pypoetry
-          key: v2-dependencies-{{ checksum "poetry.lock" }}
+          key: v3-3.8.2-dependencies-{{ checksum "poetry.lock" }}
 
+      - run:
+          name: test_bool
+          command: poetry run python -m unittest test_quickjs.FunctionTest.test_bool
+      
       - run:
           name: Tests
           command: |

--- a/test_quickjs.py
+++ b/test_quickjs.py
@@ -553,8 +553,7 @@ class QJS(object):
 
 
 class QuickJSContextInClass(unittest.TestCase):
-    @unittest.expectedFailure
     def test_github_issue_7(self):
-        # This gives stack overflow internal error, due to how QuickJS calculates stack frames.
+        # This gave stack overflow internal error, due to how QuickJS calculates stack frames.
         qjs = QJS()
         self.assertEqual(qjs.interp.eval('2+2'), 4)

--- a/third-party/quickjs.c
+++ b/third-party/quickjs.c
@@ -1573,6 +1573,7 @@ static inline BOOL js_check_stack_overflow(JSRuntime *rt, size_t alloca_size)
 {
     size_t size;
     size = rt->stack_top - js_get_stack_pointer();
+    fprintf(stderr, "Stack size is %zu.  top=%p\n", size, rt->stack_top);
     return unlikely((size + alloca_size) > rt->stack_size);
 }
 #endif

--- a/third-party/quickjs.c
+++ b/third-party/quickjs.c
@@ -1573,7 +1573,6 @@ static inline BOOL js_check_stack_overflow(JSRuntime *rt, size_t alloca_size)
 {
     size_t size;
     size = rt->stack_top - js_get_stack_pointer();
-    fprintf(stderr, "Stack size is %zu.  top=%p\n", size, rt->stack_top);
     return unlikely((size + alloca_size) > rt->stack_size);
 }
 #endif

--- a/third-party/quickjs.c
+++ b/third-party/quickjs.c
@@ -33139,6 +33139,8 @@ static JSValue JS_EvalObject(JSContext *ctx, JSValueConst this_obj,
 JSValue JS_Eval(JSContext *ctx, const char *input, size_t input_len,
                 const char *filename, int eval_flags)
 {
+    ctx->rt->stack_top = js_get_stack_pointer();
+
     int eval_type = eval_flags & JS_EVAL_TYPE_MASK;
     JSValue ret;
 


### PR DESCRIPTION
For some reason, the stack overflow detection in QuickJS does not work when Python 3.8 is used in CI. Works fine locally with all versions.