### PR TITLE
Use a newer CircleCI image, based on Ubuntu and Python 3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
 
       - restore_cache:
           keys:
-          - v2-dependencies-{{ checksum "poetry.lock" }}
+          - v1-3.8-dependencies-{{ checksum "poetry.lock" }}
 
       - run:
           name: Install dependencies
@@ -31,7 +31,7 @@ jobs:
           paths:
             - ./.venv
             - ~/.cache/pypoetry
-          key: v2-dependencies-{{ checksum "poetry.lock" }}
+          key: v1-3.8-dependencies-{{ checksum "poetry.lock" }}
 
       - run:
           name: Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,14 +9,6 @@ jobs:
     steps:
       - checkout
 
-      - run:
-          name: Install poetry
-          command: |
-            sudo apt update
-            sudo apt install python3-pip
-            sudo -H python3 -m pip install --upgrade pip
-            sudo -H python3 -m pip install --upgrade poetry
-
       - restore_cache:
           keys:
           - v1-3.8-dependencies-{{ checksum "poetry.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,8 @@ jobs:
       - run:
           name: Install poetry
           command: |
+            sudo apt update
+            sudo apt install python3-pip
             sudo -H python3 -m pip install --upgrade pip
             sudo -H python3 -m pip install --upgrade poetry
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.6.6
+      - image: cimg/python:3.8
 
     working_directory: ~/repo
 


### PR DESCRIPTION
This is the new recommended image by CircleCI. As it happens, it is based on Ubuntu and this library works with Python 3.8 in this image.