### PR TITLE
context_set: check for JS_SetPropertyStr return value.

### DIFF
--- a/module.c
+++ b/module.c
@@ -419,13 +419,15 @@ static PyObject *context_set(ContextData *self, PyObject *args) {
 		return NULL;
 	}
 	JSValue global = JS_GetGlobalObject(self->context);
-	int success = 0;
+	int ret = 0;
 	if (python_to_quickjs_possible(self, item)) {
-		JS_SetPropertyStr(self->context, global, name, python_to_quickjs(self, item));
-		success = 1;
+		ret = JS_SetPropertyStr(self->context, global, name, python_to_quickjs(self, item));
+		if (ret != 1) {
+			PyErr_SetString(PyExc_TypeError, "Failed setting the variable.");
+		}
 	}
 	JS_FreeValue(self->context, global);
-	if (success) {
+	if (ret == 1) {
 		Py_RETURN_NONE;
 	} else {
 		return NULL;


### PR DESCRIPTION
Follow-up of #55, checking for errors in JS_SetPropertyStr.

Currently uses PyExc_TypeError; not sure that it is the most sensible choice, but merely doing the same as in `context_add_callable`...