### PR TITLE
Update QuickJS to 2021-03-27

### DIFF
--- a/test_quickjs.py
+++ b/test_quickjs.py
@@ -560,8 +560,10 @@ class QJS(object):
 
 
 class QuickJSContextInClass(unittest.TestCase):
-    @unittest.expectedFailure
     def test_github_issue_7(self):
-        # This gives stack overflow internal error, due to how QuickJS calculates stack frames.
+        # This used to give stack overflow internal error, due to how QuickJS calculates stack
+        # frames. Passes with the 2021-03-27 release.
+        # 
+        # TODO: Use the new JS_UpdateStackTop function in order to better handle stacks.
         qjs = QJS()
         self.assertEqual(qjs.interp.eval('2+2'), 4)

--- a/third-party/libbf.c
+++ b/third-party/libbf.c
@@ -1,7 +1,7 @@
 /*
  * Tiny arbitrary precision floating point library
  * 
- * Copyright (c) 2017-2020 Fabrice Bellard
+ * Copyright (c) 2017-2021 Fabrice Bellard
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/third-party/libbf.h
+++ b/third-party/libbf.h
@@ -1,7 +1,7 @@
 /*
  * Tiny arbitrary precision floating point library
  * 
- * Copyright (c) 2017-2020 Fabrice Bellard
+ * Copyright (c) 2017-2021 Fabrice Bellard
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/third-party/quickjs.h
+++ b/third-party/quickjs.h
@@ -1,8 +1,8 @@
 /*
  * QuickJS Javascript Engine
  *
- * Copyright (c) 2017-2020 Fabrice Bellard
- * Copyright (c) 2017-2020 Charlie Gordon
+ * Copyright (c) 2017-2021 Fabrice Bellard
+ * Copyright (c) 2017-2021 Charlie Gordon
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -333,7 +333,11 @@ JSRuntime *JS_NewRuntime(void);
 void JS_SetRuntimeInfo(JSRuntime *rt, const char *info);
 void JS_SetMemoryLimit(JSRuntime *rt, size_t limit);
 void JS_SetGCThreshold(JSRuntime *rt, size_t gc_threshold);
+/* use 0 to disable maximum stack size check */
 void JS_SetMaxStackSize(JSRuntime *rt, size_t stack_size);
+/* should be called when changing thread to update the stack top value
+   used to check stack overflow. */
+void JS_UpdateStackTop(JSRuntime *rt);
 JSRuntime *JS_NewRuntime2(const JSMallocFunctions *mf, void *opaque);
 void JS_FreeRuntime(JSRuntime *rt);
 void *JS_GetRuntimeOpaque(JSRuntime *rt);


### PR DESCRIPTION
Fixes #57.
Also fixes #7, it seems. We should use the new `JS_UpdateStackTop` in the future though.