### PR TITLE
Fix #63: display traceback for exceptions in callables

### DIFF
--- a/module.c
+++ b/module.c
@@ -568,6 +568,7 @@ static JSValue js_c_function(
 	PyObject *result = PyObject_CallObject(node->obj, args);
 	Py_DECREF(args);
 	if (!result) {
+		PyErr_WriteUnraisable(node->obj);
 		end_call_python(context);
 		return JS_ThrowInternalError(ctx, "Python call failed.");
 	}


### PR DESCRIPTION
Simple attempt for #63 . `PyErr_WriteUnraisable` seems to fit the bill quite well with minimal work.

Test:

```python
>>> import quickjs
>>> def test():
...     1/0
... 
>>> ctx = quickjs.Context()
>>> ctx.add_callable("test", test)
>>> ctx.eval("test()")
Exception ignored in: <function test at 0x7efe29521940>
Traceback (most recent call last):
  File "<stdin>", line 2, in test
ZeroDivisionError: division by zero
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
_quickjs.JSException: InternalError: Python call failed.
    at test (native)
    at <eval> (<input>)
```