### PR TITLE
Fix #62: Implement async job execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The `Function` class has, apart from being a callable, additional methods:
 - `set_max_stack_size`
 - `memory` – returns a dict with information about memory usage.
 - `add_callable` – adds a Python function and makes it callable from JS.
+- `execute_pending_job` – executes a pending job (such as a async function or Promise).
 
 ## Documentation
 For full functionality, please see `test_quickjs.py`

--- a/module.c
+++ b/module.c
@@ -387,11 +387,9 @@ static PyObject *context_module(ContextData *self, PyObject *args) {
 //
 // If there are pending jobs, executes one and returns True. Else returns False.
 static PyObject *context_execute_pending_job(ContextData *self) {
-	JSContext *ctx;
-	JSValue value;
-	int ret;
 	prepare_call_js(self);
-	ret = JS_ExecutePendingJob(self->runtime, &ctx);
+	JSContext *ctx;
+	int ret = JS_ExecutePendingJob(self->runtime, &ctx);
 	end_call_js(self);
 	if (ret > 0) {
 		Py_RETURN_TRUE;

--- a/module.c
+++ b/module.c
@@ -237,6 +237,37 @@ static PyObject *object_call(ObjectData *self, PyObject *args, PyObject *kwds) {
 	return quickjs_to_python(self->context, value);
 }
 
+// Converts the current Javascript exception to a Python exception via a C string.
+static void quickjs_exception_to_python(JSContext *context) {
+	JSValue exception = JS_GetException(context);
+	const char *cstring = JS_ToCString(context, exception);
+	const char *stack_cstring = NULL;
+	if (!JS_IsNull(exception) && !JS_IsUndefined(exception)) {
+		JSValue stack = JS_GetPropertyStr(context, exception, "stack");
+		if (!JS_IsException(stack)) {
+			stack_cstring = JS_ToCString(context, stack);
+			JS_FreeValue(context, stack);
+		}
+	}
+	if (cstring != NULL) {
+		const char *safe_stack_cstring = stack_cstring ? stack_cstring : "";
+		if (strstr(cstring, "stack overflow") != NULL) {
+			PyErr_Format(StackOverflow, "%s\n%s", cstring, safe_stack_cstring);
+		} else {
+			PyErr_Format(JSException, "%s\n%s", cstring, safe_stack_cstring);
+		}
+	} else {
+		// This has been observed to happen when different threads have used the same QuickJS
+		// runtime, but not at the same time.
+		// Could potentially be another problem though, since JS_ToCString may return NULL.
+		PyErr_Format(JSException,
+					 "(Failed obtaining QuickJS error string. Concurrency issue?)");
+	}
+	JS_FreeCString(context, cstring);
+	JS_FreeCString(context, stack_cstring);
+	JS_FreeValue(context, exception);
+}
+
 // Converts a JSValue to a Python object.
 //
 // Takes ownership of the JSValue and will deallocate it (refcount reduced by 1).
@@ -255,34 +286,7 @@ static PyObject *quickjs_to_python(ContextData *context_obj, JSValue value) {
 	} else if (tag == JS_TAG_UNDEFINED) {
 		return_value = Py_None;
 	} else if (tag == JS_TAG_EXCEPTION) {
-		// We have a Javascript exception. We convert it to a Python exception via a C string.
-		JSValue exception = JS_GetException(context);
-		const char *cstring = JS_ToCString(context, exception);
-		const char *stack_cstring = NULL;
-		if (!JS_IsNull(exception) && !JS_IsUndefined(exception)) {
-			JSValue stack = JS_GetPropertyStr(context, exception, "stack");
-			if (!JS_IsException(stack)) {
-				stack_cstring = JS_ToCString(context, stack);
-				JS_FreeValue(context, stack);
-			}
-		}
-		if (cstring != NULL) {
-			const char *safe_stack_cstring = stack_cstring ? stack_cstring : "";
-			if (strstr(cstring, "stack overflow") != NULL) {
-				PyErr_Format(StackOverflow, "%s\n%s", cstring, safe_stack_cstring);
-			} else {
-				PyErr_Format(JSException, "%s\n%s", cstring, safe_stack_cstring);
-			}
-		} else {
-			// This has been observed to happen when different threads have used the same QuickJS
-			// runtime, but not at the same time.
-			// Could potentially be another problem though, since JS_ToCString may return NULL.
-			PyErr_Format(JSException,
-			             "(Failed obtaining QuickJS error string. Concurrency issue?)");
-		}
-		JS_FreeCString(context, cstring);
-		JS_FreeCString(context, stack_cstring);
-		JS_FreeValue(context, exception);
+		quickjs_exception_to_python(context);
 	} else if (tag == JS_TAG_FLOAT64) {
 		return_value = Py_BuildValue("d", JS_VALUE_GET_FLOAT64(value));
 	} else if (tag == JS_TAG_STRING) {
@@ -377,6 +381,26 @@ static PyObject *context_eval(ContextData *self, PyObject *args) {
 // Evaluates a Python string as JS module. Otherwise identical to eval.
 static PyObject *context_module(ContextData *self, PyObject *args) {
 	return context_eval_internal(self, args, JS_EVAL_TYPE_MODULE);
+}
+
+// _quickjs.Context.execute_pending_job
+//
+// If there are pending jobs, executes one and returns True. Else returns False.
+static PyObject *context_execute_pending_job(ContextData *self) {
+	JSContext *ctx;
+	JSValue value;
+	int ret;
+	prepare_call_js(self);
+	ret = JS_ExecutePendingJob(self->runtime, &ctx);
+	end_call_js(self);
+	if (ret > 0) {
+		Py_RETURN_TRUE;
+	} else if (ret == 0) {
+		Py_RETURN_FALSE;
+	} else {
+		quickjs_exception_to_python(ctx);
+		return NULL;
+	}
 }
 
 // _quickjs.Context.parse_json
@@ -634,6 +658,7 @@ static PyMethodDef context_methods[] = {
      (PyCFunction)context_module,
      METH_VARARGS,
      "Evaluates a Javascript string as a module."},
+    {"execute_pending_job", (PyCFunction)context_execute_pending_job, METH_NOARGS, "Execute a pending job."},
     {"parse_json", (PyCFunction)context_parse_json, METH_VARARGS, "Parses a JSON string."},
     {"get", (PyCFunction)context_get, METH_VARARGS, "Gets a Javascript global variable."},
     {"set", (PyCFunction)context_set, METH_VARARGS, "Sets a Javascript global variable."},

--- a/module.c
+++ b/module.c
@@ -658,7 +658,7 @@ static PyMethodDef context_methods[] = {
      (PyCFunction)context_module,
      METH_VARARGS,
      "Evaluates a Javascript string as a module."},
-    {"execute_pending_job", (PyCFunction)context_execute_pending_job, METH_NOARGS, "Execute a pending job."},
+    {"execute_pending_job", (PyCFunction)context_execute_pending_job, METH_NOARGS, "Executes a pending job."},
     {"parse_json", (PyCFunction)context_parse_json, METH_VARARGS, "Parses a JSON string."},
     {"get", (PyCFunction)context_get, METH_VARARGS, "Gets a Javascript global variable."},
     {"set", (PyCFunction)context_set, METH_VARARGS, "Sets a Javascript global variable."},

--- a/quickjs/__init__.py
+++ b/quickjs/__init__.py
@@ -73,6 +73,10 @@ class Function:
         with self._lock:
             self._context.gc()
 
+    def execute_pending_job(self) -> bool:
+        with self._lock:
+            return self._context.execute_pending_job()
+
     def _compile(self, name: str, code: str) -> Tuple[Context, Object]:
         context = Context()
         context.eval(code)


### PR DESCRIPTION
Fix #62.

Note that errors occurring in asynchronous code do not seem to be raised (even though the case `JS_ExecutePendingJob(...) < 0` is handled). But this seems to be the case in the native `qjs` as well.
EDIT: this seems to be a matter of using `JS_SetHostPromiseRejectionTracker`, see https://github.com/bellard/quickjs/issues/87. Should we use it, or maybe conditionally with a flag on the context (the question also applies to #64 ...)?