### PR TITLE
Fix #66: Fetch and store Python exceptions while in JS code

### DIFF
--- a/module.c
+++ b/module.c
@@ -263,7 +263,7 @@ static PyObject *quickjs_to_python(ContextData *context_obj, JSValue value) {
 		const char *cstring = JS_ToCString(context, exception);
 		const char *stack_cstring = NULL;
 		PyObject *py_stack = NULL;
-		if (context_obj->last_python_error_value == NULL) {
+		if (context_obj->last_python_error_value == NULL || cstring == NULL || strstr(cstring, "Python call failed.") == NULL) {
 			py_stack = PyUnicode_FromString("");
 		} else {
 			PyObject *tbm = PyImport_ImportModule("traceback");

--- a/test_quickjs.py
+++ b/test_quickjs.py
@@ -243,6 +243,20 @@ class CallIntoPython(unittest.TestCase):
             # instead of a JS exception.
             self.context.eval("test_list()")
 
+    def test_python_exception_with_object_return_does_not_raise_system_error(self):
+        # https://github.com/PetterS/quickjs/issues/66
+
+        def python_raise():
+            raise Exception
+
+        self.context.add_callable("python_raise", python_raise)
+        # When called, `a` should return an object (a promise),
+        # even though a Python error is generated in the background.
+        self.context.eval("async function a() {await python_raise();}")
+        # With incorrect error handling, this raised a SystemError in dev builds,
+        # and segfaulted in prod builds.
+        self.assertEqual(self.context.eval("typeof a();"), "object")
+
 
 class Object(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Fix #63, fix #66.

In contrast to JS, Python exceptions are global. So to support the case where an exception is raised in an asynchronous segment, one needs to store away the exception and unset the error indicator.

This stored exception can then be raised if it is returned on the JS side, or as part of a `HostPromiseRejectionTracker`.

Note: that mechanism is also needed to properly handle nested Python -> JS -> Python -> JS -> Python cases:

```python
import quickjs
ctx = quickjs.Context()

def testa():
    ctx.eval("testb()")

def testb():
    raise Exception

ctx.add_callable("testa", testa)
ctx.add_callable("testb", testb)
ctx.eval("testa()")
```

This also supersedes #64.