### PR TITLE
Fix #61: compile with BigInt support and add conversion to Python

### DIFF
--- a/module.c
+++ b/module.c
@@ -248,6 +248,9 @@ static PyObject *quickjs_to_python(ContextData *context_obj, JSValue value) {
 
 	if (tag == JS_TAG_INT) {
 		return_value = Py_BuildValue("i", JS_VALUE_GET_INT(value));
+	} else if (tag == JS_TAG_BIG_INT) {
+		const char *cstring = JS_ToCString(context, value);
+		return_value = PyLong_FromString(cstring, NULL, 10);
 	} else if (tag == JS_TAG_BOOL) {
 		return_value = Py_BuildValue("O", JS_VALUE_GET_BOOL(value) ? Py_True : Py_False);
 	} else if (tag == JS_TAG_NULL) {

--- a/module.c
+++ b/module.c
@@ -251,6 +251,7 @@ static PyObject *quickjs_to_python(ContextData *context_obj, JSValue value) {
 	} else if (tag == JS_TAG_BIG_INT) {
 		const char *cstring = JS_ToCString(context, value);
 		return_value = PyLong_FromString(cstring, NULL, 10);
+		JS_FreeCString(context, cstring);
 	} else if (tag == JS_TAG_BOOL) {
 		return_value = Py_BuildValue("O", JS_VALUE_GET_BOOL(value) ? Py_True : Py_False);
 	} else if (tag == JS_TAG_NULL) {

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ def get_c_sources(include_headers=False):
 
 _quickjs = Extension(
     '_quickjs',
-    define_macros=[('CONFIG_VERSION', f'"{CONFIG_VERSION}"')],
+    define_macros=[('CONFIG_VERSION', f'"{CONFIG_VERSION}"'), ('CONFIG_BIGNUM', None)],
     # HACK.
     # See https://github.com/pypa/packaging-problems/issues/84.
     sources=get_c_sources(include_headers=("sdist" in sys.argv)),

--- a/test_quickjs.py
+++ b/test_quickjs.py
@@ -502,6 +502,11 @@ class JavascriptFeatures(unittest.TestCase):
         self.assertEqual(f(11), 11)
         self.assertEqual(f(None), 42)
 
+    def test_bigint(self):
+        context = quickjs.Context()
+        self.assertEqual(context.eval(f"BigInt('{10**100}')"), 10**100)
+        self.assertEqual(context.eval(f"BigInt('{-10**100}')"), -10**100)
+
 
 class Threads(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Fix #61.

AFAIAC, we can restrict ourselves to `BigInt`, `BigInt64Array` and `BigUint64Array` (the standard set) without enabling `quickjs`-specific extensions (`BigFloat`, `BigDecimal`, `use math`, ...).

Currently I implemented the JS -> Python conversion. I am unsure about the other direction:
- Python integers unlimited both in size and precision.
- JS has no upper limit on standard numbers, though it uses float semantics for large numbers (e-formatting, precision loss, Infinity, ...).
- The current implementation in `module.c` uses a C long for the conversion and thus fails for large integers (actually, this can be considered a bug in the current `python_to_quickjs_possible`).

```python
>>> import quickjs
>>> ctx = quickjs.Context()
>>> ctx.set("a", 10**100)
OverflowError: Python int too large to convert to C long

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
SystemError: <method 'set' of '_quickjs.Context' objects> returned a result with an error set
```

So I see three possible paths:
- Explicitely forbid Python -> JS conversions if the number does not fit in a C long
  - pro: easy
  - con: does not use Python/JS capabilities to their full potential (introduces arbitrary limitation)
- Allow them, using a Python float / C double for the conversion
  - pro: respects JS number semantics (float-like numbers)
  - con: does not respect Python integer semantics (unlimited precision)
- Allow them, converting to `BigInt`
  - pro: exact
  - con: imprevisible behavior (target type depends on the input value; `BigInt`'s and standard numbers are not freely mixable in JS).

NOTE: currently, in the other direction, a Python float is returned when the value does not fit in a C long. So the second path may be the most reasonable. EDIT: see the tentative implementation in #71.