### PR TITLE
Fix conversion of large Python integers to quickjs

### DIFF
--- a/module.c
+++ b/module.c
@@ -187,7 +187,14 @@ static JSValueConst python_to_quickjs(ContextData *context, PyObject *item) {
 	if (PyBool_Check(item)) {
 		return JS_MKVAL(JS_TAG_BOOL, item == Py_True ? 1 : 0);
 	} else if (PyLong_Check(item)) {
-		return JS_MKVAL(JS_TAG_INT, PyLong_AsLong(item));
+		int overflow;
+		long value = PyLong_AsLongAndOverflow(item, &overflow);
+		if (overflow) {
+			PyObject *float_value = PyNumber_Float(item);
+			return JS_NewFloat64(context->context, PyFloat_AsDouble(float_value));
+		} else {
+			return JS_MKVAL(JS_TAG_INT, value);
+		}
 	} else if (PyFloat_Check(item)) {
 		return JS_NewFloat64(context->context, PyFloat_AsDouble(item));
 	} else if (item == Py_None) {

--- a/test_quickjs.py
+++ b/test_quickjs.py
@@ -502,6 +502,14 @@ class JavascriptFeatures(unittest.TestCase):
         self.assertEqual(f(11), 11)
         self.assertEqual(f(None), 42)
 
+    def test_large_python_integers_to_quickjs(self):
+        context = quickjs.Context()
+        # Without a careful implementation, this made Python raise a SystemError/OverflowError.
+        context.set("v", 10**25)
+        # There is precision loss occurring in JS due to
+        # the floating point implementation of numbers.
+        self.assertTrue(context.eval("v == 1e25"))
+
 
 class Threads(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Implement the conversion of Python integers to quickjs when they are too large to fit in a C long.

By symmetry to the reverse operation, converts the value to a float (possibly losing precision in the process), which can then be transferred transparently to JS.