### PR TITLE
Implement a host promise rejection tracker with Python callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The `Function` class has, apart from being a callable, additional methods:
 - `memory` – returns a dict with information about memory usage.
 - `add_callable` – adds a Python function and makes it callable from JS.
 - `execute_pending_job` – executes a pending job (such as a async function or Promise).
+- `set_promise_rejection_tracker` - sets a callback receiving (promise, reason, is_handled) when a promise is rejected. Pass None to disable.
 
 ## Documentation
 For full functionality, please see `test_quickjs.py`

--- a/test_quickjs.py
+++ b/test_quickjs.py
@@ -256,8 +256,10 @@ class CallIntoPython(unittest.TestCase):
         def tracker(promise, reason, is_handled):
             called[0] += 1
             self.assertFalse(is_handled)
+            self.context.set("reason", reason)
+            self.assertTrue(self.context.eval("reason.message === 'x';"))
         def run_async_error():
-            self.context.eval("function f() {throw Error;}")
+            self.context.eval("function f() {throw Error('x');}")
             self.context.eval("async function g() {await f();}")
             self.context.eval("g()")
         self.context.set_promise_rejection_tracker(tracker)


### PR DESCRIPTION
As discussed in my roadmap presented in #67.

This feature goes hand-in-hand with the job execution from #65.