### PR TITLE
Implement Object.get and Object.set

### DIFF
--- a/test_quickjs.py
+++ b/test_quickjs.py
@@ -346,6 +346,21 @@ class Object(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "Can not mix JS objects from different contexts."):
             f(d)
 
+    def test_get(self):
+        self.context.eval("a = {x: 42, y: 'foo'};")
+        a = self.context.get("a")
+        self.assertEqual(a.get("x"), 42)
+        self.assertEqual(a.get("y"), "foo")
+        self.assertEqual(a.get("z"), None)
+
+    def test_set(self):
+        self.context.eval("a = {x: 'overridden'}")
+        a = self.context.get("a")
+        a.set("x", 42)
+        a.set("y", "foo")
+        self.assertTrue(self.context.eval("a.x == 42"))
+        self.assertTrue(self.context.eval("a.y == 'foo'"))
+
 
 class FunctionTest(unittest.TestCase):
     def test_adder(self):


### PR DESCRIPTION
Implement `Object.get` and `Object.set` using the same ideas as `Context.get` and `Context.set`.

Currently it is very tedious to get or set an object property. When the object is only known via its Python wrapper, one has to first rebind it to the global context using `Context.set` and then access it with `Context.get`. With this, one could directly access or set the property via the Python wrapper.

The `json()` method is not sufficient for this, as it does not expose properties from the prototype.

Discussion:
- What about merging these methods with those of Context, as in, treating the Context as an Object? (Remove the `get`, `set`, etc. methods of Context, add a generic `get_global` or similar to get the global object from the context)
Further discussion (for the future?):
- What about `add_callable`? Should Object also support it? Should we merge `set` and `add_callable`?
- What about having a more transparent interface between JS and Python? Like being able to access properties of Object with the standard dot syntax (and/or square brackets lookup?)?