### PR TITLE
Use JS_UpdateStackTop to fix testing errors on Windows

### DIFF
--- a/module.c
+++ b/module.c
@@ -82,6 +82,7 @@ static void prepare_call_js(RuntimeData *runtime_data) {
 	// We release the GIL in order to speed things up for certain use cases.
 	assert(!runtime_data->thread_state);
 	runtime_data->thread_state = PyEval_SaveThread();
+	JS_UpdateStackTop(runtime_data->runtime);
 	setup_time_limit(runtime_data, &runtime_data->interrupt_data);
 }
 

--- a/test_quickjs.py
+++ b/test_quickjs.py
@@ -671,7 +671,5 @@ class QuickJSContextInClass(unittest.TestCase):
     def test_github_issue_7(self):
         # This used to give stack overflow internal error, due to how QuickJS calculates stack
         # frames. Passes with the 2021-03-27 release.
-        # 
-        # TODO: Use the new JS_UpdateStackTop function in order to better handle stacks.
         qjs = QJS()
         self.assertEqual(qjs.interp.eval('2+2'), 4)


### PR DESCRIPTION
Without it, the `FunctionTest.test_execute_pending_job` unit test fails (`obj` is not updated).