### PR TITLE
Add types

### DIFF
--- a/_quickjs.pyi
+++ b/_quickjs.pyi
@@ -1,0 +1,60 @@
+from typing import Any, Callable, Literal, TypedDict
+
+
+def test() -> Literal[1]: ...
+
+JSValue = None | bool | int | float | str | Object
+
+class Object():
+    def json(self) -> str: ...
+    def __call__(self, *args: Any) -> Any: ...
+
+class MemoryDict(TypedDict):
+    malloc_size: int
+    malloc_limit: int
+    memory_used_size: int
+    malloc_count: int
+    memory_used_count: int
+    atom_count: int
+    atom_size: int
+    str_count: int
+    str_size: int
+    obj_count: int
+    obj_size: int
+    prop_count: int
+    prop_size: int
+    shape_count: int
+    shape_size: int
+    js_func_count: int
+    js_func_size: int
+    js_func_code_size: int
+    js_func_pc2line_count: int
+    js_func_pc2line_size: int
+    c_func_count: int
+    array_count: int
+    fast_array_count: int
+    fast_array_elements: int
+    binary_object_count: int
+    binary_object_size: int
+
+class Context:
+    def eval(self, code: str) -> JSValue: ...
+    def module(self, code: str) -> JSValue: ...
+    def execute_pending_job(self) -> bool: ...
+    def parse_json(self, data: str) -> JSValue: ...
+    def get(self, name: str) -> JSValue: ...
+    def set(self, name: str, item: JSValue) -> None: ...
+    def set_memory_limit(self, limit: int) -> None: ...
+    def set_time_limit(self, limit: int) -> None: ...
+    def set_max_stack_size(self, limit: int) -> None: ...
+    def memory(self) -> MemoryDict: ...
+    def gc(self) -> None: ...
+    def add_callable(self, name: str, callable: Callable[..., Any]) -> None: ...
+    @property
+    def globalThis(self) -> Object: ...
+
+class JSException(Exception):
+    pass
+
+class StackOverflow(Exception):
+    pass

--- a/module.c
+++ b/module.c
@@ -642,7 +642,7 @@ static PyObject *runtime_set_max_stack_size(RuntimeData *self, PyObject *args) {
 
 // _quickjs.Context.memory
 //
-// Sets the CPU time limit of the context. This will be used in an interrupt handler.
+// Returns the memory usage as a dict.
 static PyObject *runtime_memory(RuntimeData *self) {
 	PyObject *dict = PyDict_New();
 	if (dict == NULL) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Python wrapper around https://bellard.org/quickjs/"
 authors = ["Petter Strandmark"]
 
 [tool.poetry.dependencies]
-python = ">=3.6"
+python = ">=3.7"
 
 [tool.poetry.dev-dependencies]
 yapf = "*"

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import glob
 import sys
 from typing import List
 
@@ -16,13 +15,13 @@ if sys.platform == "win32":
     #    system PATH when compiling.
     # 3. The code below will moneky-patch distutils to work.
     import distutils.cygwinccompiler
-    distutils.cygwinccompiler.get_msvcr = lambda: [] 
+    distutils.cygwinccompiler.get_msvcr = lambda: []  # type: ignore
     # Make sure that pthreads is linked statically, otherwise we run into problems
     # on computers where it is not installed.
     extra_link_args = ["-static"]
 
 
-def get_c_sources(include_headers=False):
+def get_c_sources(include_headers: bool = False):
     sources = [
         "module.c",
         "upstream-quickjs/cutils.c",
@@ -77,4 +76,9 @@ setup(author="Petter Strandmark",
       description='Wrapping the quickjs C library.',
       long_description=long_description,
       packages=["quickjs"],
-      ext_modules=[_quickjs])
+      ext_modules=[_quickjs],
+      package_data={
+          "": ["_quickjs.pyi"],
+          "quickjs": ["py.typed"]
+      },
+      include_package_data=True,)


### PR DESCRIPTION
This adds types to the compiled module in `_quickjs.pyi` and completes the types in `quickjs/__init__.py`.
Inline types are supported since Python 3.7 and since they are already used in the project and the tests are only run on Python 3.7+ the required Python version was changed from 3.6 to 3.7.